### PR TITLE
Systemd

### DIFF
--- a/init/systemd/waagent.rs.service
+++ b/init/systemd/waagent.rs.service
@@ -9,9 +9,9 @@ ConditionPathExists=/etc/waagent.conf
 
 [Service]
 Type=simple
-#User=waagent-rs
-WorkingDirectory=/home/azureAdmin/waagent-rs
-ExecStart=/home/azureAdmin/waagent-rs/target/release/waagent-rs-poc
+User=waagent-rs
+WorkingDirectory=/usr/bin
+ExecStart=/usr/bin/waagent-rs-poc
 Restart=always
 Restart=always
 RestartSec=5

--- a/init/systemd/waagent.rs.service
+++ b/init/systemd/waagent.rs.service
@@ -4,7 +4,7 @@ Description=Azure Linux Agent
 Wants=network-online.target sshd.service sshd-keygen.service
 After=network-online.target
 
-ConditionFileIsExecutable=/usr/sbin/waagent
+ConditionFileIsExecutable=/usr/bin/waagent-rs-poc
 ConditionPathExists=/etc/waagent.conf
 
 [Service]

--- a/init/systemd/waagent.rs.service
+++ b/init/systemd/waagent.rs.service
@@ -8,7 +8,7 @@ Description=Azure Linux Agent
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python -u /usr/sbin/waagent -daemon
+ExecStart=cargo run /usr/sbin/waagent-poc/main.rs -daemon
 Restart=always
 RestartSec=5
 

--- a/init/systemd/waagent.rs.service
+++ b/init/systemd/waagent.rs.service
@@ -1,13 +1,16 @@
 [Unit]
-Description=Azure Provisioning
+Description=Azure Linux Agent
+#Wants=network-online.target sshd.service sshd-keygen.service
+#After=network-online.target
+
+#ConditionFileIsExecutable=/usr/sbin/waagent
+#ConditionPathExists=/etc/waagent.conf
 
 [Service]
-Type=oneshot
-ExecStart=/usr/bin/python3 /usr/local/azure-provisioning.py
-ExecStart=/bin/bash -c "hostnamectl set-hostname $(curl \
-    -H 'metadata: true' \
-    'http://169.254.169.254/metadata/instance/compute/name?api-version=2019-06-01&format=text')"
-ExecStart=/usr/bin/systemctl disable azure-provisioning.service
+Type=simple
+ExecStart=/usr/bin/python -u /usr/sbin/waagent -daemon
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/init/systemd/waagent.rs.service
+++ b/init/systemd/waagent.rs.service
@@ -1,14 +1,18 @@
+# /etc/systemd/system/waagent-rs.service
 [Unit]
 Description=Azure Linux Agent
-#Wants=network-online.target sshd.service sshd-keygen.service
-#After=network-online.target
+Wants=network-online.target sshd.service sshd-keygen.service
+After=network-online.target
 
-#ConditionFileIsExecutable=/usr/sbin/waagent
-#ConditionPathExists=/etc/waagent.conf
+ConditionFileIsExecutable=/usr/sbin/waagent
+ConditionPathExists=/etc/waagent.conf
 
 [Service]
 Type=simple
-ExecStart=cargo run /usr/sbin/waagent-poc/main.rs -daemon
+#User=waagent-rs
+WorkingDirectory=/home/azureAdmin/waagent-rs
+ExecStart=/home/azureAdmin/waagent-rs/target/release/waagent-rs-poc
+Restart=always
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
Systemd unit tested on Ubuntu 24.04 that implements waagent-rs-poc as a service. Place System d unit under /etc/systemd/system/waagent-rs.service. Then run the following to build binary:

git clone https://github.com/waagent-rs/waagent-rs.git
cd waagent-rs
cargo build --release

Place resulting waagent-rs-poc binary in /usr/bin. Binary is ran by user waagent-rs so ensure user is present steps to do so are below:

sudo useradd -u 999 -r -d /nonexistent -s /usr/sbin/nologin waagent-rs
sudo cp waagent-poc/sudoers.d/waagent-rs /etc/sudoers.d
sudo systemctl stop walinuxagent
sudo -u waagent-rs target/release/waagent-rs-poc

Once binary built and user added the systemd unit can be enabled (so that the unit runs at boot) and started with the commands:

sudo systemctl enable waagent-rs.service
sudo systemctl start waagent-rs.service
